### PR TITLE
YAML Configuration Support

### DIFF
--- a/lib/decking.js
+++ b/lib/decking.js
@@ -51,7 +51,7 @@ Decking.prototype.execute = function(done) {
   }
 
   if(this.command != "help") {
-    this.config = this.loadConfig("./decking.json");
+    this.config = this.loadConfig();
   }
 
   return fn.call(this, function(err) {
@@ -64,18 +64,22 @@ Decking.prototype.execute = function(done) {
  *
  * @return {String}
  */
-Decking.prototype.loadConfig = function(file) {
+Decking.prototype.loadConfig = function() {
   // Check for existance
   var yamlConfig = fs.existsSync("./decking.yaml");
   var jsonConfig = fs.existsSync("./decking.json");
 
+  var config = null;
   if (yamlConfig && jsonConfig) {
     throw new Error("Both decking.json and decking.yaml have been found. Please remove one.");
   } else if (yamlConfig){
-    return Parser.load(YAML.safeLoad((fs.readFileSync("./decking.yaml"))));
+    config = YAML.safeLoad(fs.readFileSync("./decking.yaml"));
+  } else if (jsonConfig) {
+    config = JSON.parse(fs.readFileSync("./decking.json"));
   } else {
-    return Parser.load(JSON.parse((fs.readFileSync("./decking.json"))));
+    throw new Error("could not find either 'decking.json' or 'decking.yaml'");
   }
+  return Parser.load(config);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "grunt-simple-mocha": "~0.4.0",
     "chai": "~1.8.1",
     "sinon-chai": "~2.4.0",
-    "sinon": "~1.7.3"
+    "sinon": "~1.10.3"
   }
 }


### PR DESCRIPTION
Added support for either decking.yaml or decking.json
An error will be thrown when both or neither are present.

Added tests as well.
Updated sinon to 1.10.3 (didn't realize until i after i pushed it)
