### PR TITLE
Fix group container config to support dependency

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -90,6 +90,37 @@ Parser.prototype.load = function(config) {
       details.group = name;
     }
 
+    if(config.groups && config.groups[name] && config.groups[name].containers) {
+      _.each(config.groups[name].containers, function(container, name) {
+        if(container.dependencies) {
+          container.dependencies.forEach(function(dependency, key) {
+
+            // it's nicer for rest of the app to work with dependencies and alises
+            // as separate arrays
+            var parts = dependency.split(":");
+            var dep = parts[0];
+            var alias = parts[1];
+
+            // if we didn't get dep:alias, assume dep:dep
+            if(!alias) {
+              alias = dep;
+            }
+
+            if(!config.containers[dep]) {
+              throw new Error(
+                "Dependency '" + dep + "' of container '" + name + "' does not exist!"
+              );
+            }
+
+            container.dependencies[key] = dep;
+            container.aliases = [];
+            container.aliases[key] = alias;
+          });
+
+        }
+      });
+    }
+
     if(!details.containers.length) {
       throw new Error("Cluster '" + name + "' is empty");
     }

--- a/test/parser.js
+++ b/test/parser.js
@@ -242,6 +242,46 @@ describe("Parser", function() {
           expect(this.config.containers.test.aliases).to.eql(["alias1"]);
         });
       });
+
+      describe("when specified in a container override", function() {
+        beforeEach(function() {
+          this.config = {
+            containers: { 
+              test: {
+                image: "image/test"
+              },
+              dep1: {
+                image: "image/dep1"
+              }
+            },
+            clusters: {
+              test: ["dep1"]
+            },
+            groups: {
+              test: {
+                containers: {
+                  test: {
+                    dependencies: ["dep1"]
+                  }
+                }
+              }
+            }
+          };
+          return Parser.load(this.config);
+        });
+
+        it("correctly parses the short dependency form", function() {
+          expect(this.config.groups.test.containers.test.dependencies).to.eql(["dep1"]);
+          expect(this.config.groups.test.containers.test.aliases).to.eql(["dep1"]);
+        });
+
+        it("correctly parses the standard dependency form", function() {
+          this.config.groups.test.containers.test.dependencies = ["dep1:alias1"];
+          Parser.load(this.config);
+          expect(this.config.groups.test.containers.test.dependencies).to.eql(["dep1"]);
+          expect(this.config.groups.test.containers.test.aliases).to.eql(["alias1"]);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
You can't add a dependency to a group container override b/c the parser doesn't split the alias from the container as it does in the container block.

This PR fixes that by running the same code block for dependency splitting used by the container iterator against any dependencies added to a group.

This is a hack and duplicates code, but I'm PR'ing this anyway due to time constraints.  For me, this fixes the issue.
