### PR TITLE
halt and catch fire on errors in build

### DIFF
--- a/lib/decking.js
+++ b/lib/decking.js
@@ -203,15 +203,26 @@ Decking.prototype._build = function(image, done) {
       fs.unlink("./Dockerfile", function(err) {
         if(err) return self.logger.log("[WARN] Could not remove Dockerfile");
       });
+
       if(err) return done(err);
+
+      errors = [];
       if(res.headers["content-type"] === "application/json") {
         res.pipe(JSONStream.parse("stream")).pipe(process.stdout);
+        err_stream = res.pipe(JSONStream.parse("error"));
+        err_stream.on('data', function(chunk){
+          errors.push(chunk);
+        });
+        err_stream.pipe(process.stderr);
       } else {
         // we don't need an if/else but let's keep it for clarity; it'd be too easy to
         // skim-read the code and misinterpret the first pipe otherwise
         res.pipe(process.stdout);
       }
-      return res.on("end", done);
+      return res.on("end", function(){
+        if (errors.length > 0) { return done(errors.join("\n")); }
+        return done();
+      });
     });
   });
 

--- a/lib/decking.js
+++ b/lib/decking.js
@@ -206,10 +206,10 @@ Decking.prototype._build = function(image, done) {
 
       if(err) return done(err);
 
-      errors = [];
+      var errors = [];
       if(res.headers["content-type"] === "application/json") {
         res.pipe(JSONStream.parse("stream")).pipe(process.stdout);
-        err_stream = res.pipe(JSONStream.parse("error"));
+        var err_stream = res.pipe(JSONStream.parse("error"));
         err_stream.on('data', function(chunk){
           errors.push(chunk);
         });


### PR DESCRIPTION
Also capture the errors from the dockerode build stream; if any are received, die with an explanation.