### PR TITLE
Fix decking build

### DIFF
--- a/lib/decking.js
+++ b/lib/decking.js
@@ -297,7 +297,7 @@ Decking.prototype._build = function(image, tag, done) {
   self.logger.log("Uploading compressed context...");
 
   baseArgs = ["-c", "-"];
-  args = includes.length === 0 ? baseArgs.concat(["./"]) : baseArgs.concat(['Dockerfile']).concat(includes);
+  args = includes.length === 0 ? baseArgs.concat(["./"]) : baseArgs.concat(dockerfile).concat(includes);
   tarOptions = {cwd: context};
   tar = child_process.spawn("tar", args, tarOptions);
 


### PR DESCRIPTION
When using images.path and images.includes options, build fails with the following message:

[ERROR] could not build image: Error: HTTP code is 500 which indicates error: server error - Cannot locate specified Dockerfile: docker/containerA/Dockerfile
