### PR TITLE
Skip destroying data containers

### DIFF
--- a/lib/decking.js
+++ b/lib/decking.js
@@ -898,7 +898,9 @@ Decking.prototype._destroyIterator = function(details, callback) {
     v: true
   };
 
-  if (isData) {
+  var all = this.args.length >= 2 ? this.args[1] : null;
+
+  if (isData && all !== "all") {
     self.table.renderFinal(name, "skipping...");
     return callback();
   }

--- a/lib/decking.js
+++ b/lib/decking.js
@@ -898,6 +898,11 @@ Decking.prototype._destroyIterator = function(details, callback) {
     v: true
   };
 
+  if (isData) {
+    self.table.renderFinal(name, "skipping...");
+    return callback();
+  }
+
   this.table.render(name, "destroying...");
 
   return container.remove(params, function(err) {


### PR DESCRIPTION
Submitting this minor change to always skip destroying data containers, until 0.5.0 arrives with possibly a more comprehensive ability to control under which conditions data only containers can be destroyed.

See issue #86.