### PR TITLE
Add support for predefined build args

### DIFF
--- a/lib/decking.js
+++ b/lib/decking.js
@@ -216,6 +216,7 @@ Decking.prototype._build = function(image, tag, done) {
   var target;
   var includes;
   var context;
+  var buildargs;
   var localPath;
   var contextRoot;
   var dockerfile;
@@ -292,6 +293,45 @@ Decking.prototype._build = function(image, tag, done) {
   if (self.hasArg("--no-cache")) {
     self.logger.log("Not using image cache");
     options.nocache = true;
+  }
+
+  buildargs = {};
+
+  if (process.env.http_proxy) {
+    buildargs.http_proxy = process.env.http_proxy;
+  }
+
+  if (process.env.HTTP_PROXY) {
+    buildargs.HTTP_PROXY = process.env.HTTP_PROXY;
+  }
+
+  if (process.env.https_proxy) {
+    buildargs.https_proxy = process.env.https_proxy;
+  }
+
+  if (process.env.HTTPS_PROXY) {
+    buildargs.HTTPS_PROXY = process.env.HTTPS_PROXY;
+  }
+
+  if (process.env.ftp_proxy) {
+    buildargs.ftp_proxy = process.env.ftp_proxy;
+  }
+
+  if (process.env.FTP_PROXY) {
+    buildargs.FTP_PROXY = process.env.FTP_PROXY;
+  }
+
+  if (process.env.no_proxy) {
+    buildargs.no_proxy = process.env.no_proxy;
+  }
+
+  if (process.env.NO_PROXY) {
+    buildargs.NO_PROXY = process.env.NO_PROXY;
+  }
+
+  if (Object.keys(buildargs).length > 0) {
+    options.buildargs = JSON.stringify(buildargs);
+    self.logger.log("Build args: " + options.buildargs);
   }
 
   self.logger.log("Uploading compressed context...");


### PR DESCRIPTION
Docker >= 1.9 supports build args, see https://docs.docker.com/engine/reference/builder/#arg

Add support for predefined build args, i.e.:
- HTTP_PROXY
- http_proxy
- HTTPS_PROXY
- https_proxy
- FTP_PROXY
- ftp_proxy
- NO_PROXY
- no_proxy
